### PR TITLE
Changed logger output for console to simple to make it easier to read

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,9 @@ dotenv.config();
 // Configure the logger
 logger.configure({
     level: "debug",
-    transports: [new logger.transports.Console()],
+    transports: [new logger.transports.Console({
+        format: logger.format.simple(),
+    })],
 });
 
 const client = new Client()


### PR DESCRIPTION
Makes logger output easier to read, the default is still JSON so once the log goes into a file, it will still use JSON.